### PR TITLE
로그인/회원가입 페이지 예외처리

### DIFF
--- a/src/components/login/GoogleButton.tsx
+++ b/src/components/login/GoogleButton.tsx
@@ -4,19 +4,58 @@ import { GoogleImg } from '../../components';
 import { userLogin } from '../../utils/api/auth';
 import { RequestTokenSpace } from 'LoginModule';
 
-const responseGoogle = (response: any) => {
+const handleFailed = (response: any) => { console.log('로그인 에러', response); };
+
+const handleLoginSuccess = (response: any) => {
     const auth_token: RequestTokenSpace.GoogleToken = {
         auth_token: response.getAuthResponse().id_token
     };
-    userLogin('google', auth_token);
+    isLoginRegistered(auth_token);
 }
+
+const handleSignUpSuccess = (response: any) => {
+    const auth_token: RequestTokenSpace.GoogleToken = {
+        auth_token: response.getAuthResponse().id_token
+    };
+    isSignUpRegistered(auth_token);
+}
+
+// 로그인 시 기가입자 여부 확인
+async function isLoginRegistered(token: RequestTokenSpace.GoogleToken) {
+    try {
+        const response = await userLogin('google', token);
+
+        if (response === "False") { // 가입되지 않은 유저라면
+            alert('가입되지 않은 회원입니다. 회원가입 페이지로 이동합니다.');
+            window.open('/signup', "_self");
+        } else { // 가입된 유저라면
+            window.open('/', "_self");
+        }
+    }
+    catch (error) { console.log('구글 로그인 에러', error); };
+};
+
+// 회원가입 시 기가입자 여부 확인
+async function isSignUpRegistered(token: RequestTokenSpace.GoogleToken) {
+    try {
+        const response = await userLogin('google', token);
+
+        if (response === "False") { // 가입되지 않은 유저라면
+            window.open('/signup', "_self");
+        } else { // 가입된 유저라면
+            alert('이미 가입된 유저입니다. 자동 로그인합니다.');
+            window.open('/', "_self");
+        }
+    }
+    catch (error) { console.log('구글 로그인 에러', error); };
+};
 
 const GoogleLoginButton = () => {
     return (
         <GoogleLogin
             clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID || ""}
-            onSuccess={responseGoogle}
-            onFailure={responseGoogle}
+            onSuccess={handleLoginSuccess}
+            onFailure={handleFailed}
             cookiePolicy='single_host_origin'
             render={renderProps => (
                 <GoogleButton
@@ -34,8 +73,8 @@ const GoogleSignUpIcon = () => {
     return (
         <GoogleLogin
             clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID || ""}
-            onSuccess={responseGoogle}
-            onFailure={responseGoogle}
+            onSuccess={handleSignUpSuccess}
+            onFailure={handleFailed}
             cookiePolicy='single_host_origin'
             render={renderProps => (
                 <button

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -7,6 +7,13 @@ import { useEffect } from 'react';
 import { naverClient, githubClient } from '../../utils/data/loginApiKey';
 import { LoginSpace } from 'LoginModule';
 
+function isLogin(): void {
+    if (sessionStorage?.getItem('userProfile')) {
+        alert('이미 로그인 중입니다. 홈으로 이동합니다.');
+        window.open('/', '_self');
+    };
+};
+
 const Login = () => {
 
     // recoil 페이지 초기화
@@ -25,12 +32,15 @@ const Login = () => {
 
     // 네이버와 깃허브는 일시 잠금
     function handleClick(event: any) {
-        // const redirectUri: string = setRedirectUri(event.target.name);
+        // const redirectUri: strigit ng = setRedirectUri(event.target.name);
         // window.open(redirectUri, "_self");
     }
 
     // 회원가입 페이지 번호 리셋
-    useEffect(() => setPage(0));
+    useEffect(() => {
+        setPage(0);
+        isLogin();
+    });
 
     return (
         <LoginContainer>

--- a/src/pages/login/LoginContainer.tsx
+++ b/src/pages/login/LoginContainer.tsx
@@ -11,7 +11,7 @@ const LoginContainer: React.FC<LoginSpace.LoginContainerProps> = ({ children }) 
     return (
         <ContainerArticle>
             <FormDiv pathname={pathname}>
-                { children }
+                {children}
             </FormDiv>
         </ContainerArticle>
     );
@@ -34,7 +34,7 @@ export const ContainerArticle = styled.article`
 `;
 
 // 흰색 배경 div
-const FormDiv = styled.div<{pathname: string}>`
+const FormDiv = styled.div<{ pathname: string }>`
     background-color: white;
 
     width: ${props => props.pathname === '/login' ? '29.2vw' : '52vw'};

--- a/src/pages/login/SignUp.tsx
+++ b/src/pages/login/SignUp.tsx
@@ -3,6 +3,7 @@ import { SignUpUser, SignUpCompleted } from './index';
 import { useRecoilValue } from 'recoil';
 import { pageState } from '../../utils/data/atom';
 import { LoginSpace } from 'LoginModule';
+import { useEffect } from 'react';
 
 const SignUp = () => {
 
@@ -21,9 +22,8 @@ const SignUp = () => {
             )
         }
     }
-    
-    const renderPage = renderHTML();
 
+    const renderPage = renderHTML();
 
     return (
         <LoginContainer>

--- a/src/pages/login/SignUpUser.tsx
+++ b/src/pages/login/SignUpUser.tsx
@@ -4,19 +4,33 @@ import { useForm } from "react-hook-form";
 import { useSetRecoilState } from 'recoil';
 import { pageState } from '../../utils/data/atom';
 import { LoginSpace } from 'LoginModule';
+import { setSignUpProfile } from '../../utils/api/auth';
 
 const SignUpUser = () => {
 
     // useForm 세팅
     const { register, handleSubmit, formState: { errors } } = useForm<LoginSpace.SignUpProps>();
     const onSubmit = handleSubmit(data => {
-        console.log(data);
-        // 서버로 보내서 가입 시키는 로직 들어가야함
-        setPage(1);
+        addProfile(data);
     });
 
     // recoil 페이지 세팅
     const setPage = useSetRecoilState<LoginSpace.SignUpPageProps>(pageState);
+
+    // 유저 이메일은 고정
+    const userEmail: string = JSON.parse(sessionStorage?.getItem('userProfile') || "")?.name;
+
+    // 유저 추가 정보 업데이트하는 API
+    async function addProfile(data: LoginSpace.SignUpProps) {
+        try {
+            const response = await setSignUpProfile(data);
+
+            if (response.data.success) setPage(1);
+            if (!response.data.success) alert('유저 정보 업데이트에 실패했습니다.');
+        }
+        catch (error) { console.log('유저 추가 정보 업데이트 에러', error); };
+    };
+
 
     // 더미 데이터
     const jobOptions = [
@@ -35,18 +49,18 @@ const SignUpUser = () => {
                 <FormDiv>
                     <InformationDiv>
                         <p>이메일</p>
-                        <p>example@naver.com</p>
+                        <p>{userEmail}</p>
                     </InformationDiv>
                     <InformationDiv>
                         <p>이름</p>
                         <LoginInput
                             placeholder='이름'
-                            {...register('userName', { required: "이름을 입력해주세요." })} />
+                            {...register('name', { required: "이름을 입력해주세요." })} />
                     </InformationDiv>
-                    {errors.userName && <ErrorP>{errors.userName.message}</ErrorP>}
+                    {errors.name && <ErrorP>{errors.name.message}</ErrorP>}
                     <InformationDiv>
                         <p>직군</p>
-                        <LoginInput list="job" placeholder="직군을 선택해주세요." {...register('userJob', {
+                        <LoginInput list="job" placeholder="직군을 선택해주세요." {...register('job', {
                             required: "직군을 선택해주세요.",
                         })} />
                         <datalist id="job">
@@ -55,7 +69,7 @@ const SignUpUser = () => {
                             })}
                         </datalist>
                     </InformationDiv>
-                    {errors.userJob && <ErrorP>{errors.userJob.message}</ErrorP>}
+                    {errors.job && <ErrorP>{errors.job.message}</ErrorP>}
                 </FormDiv>
                 <LoginButton type='submit' text='가입하기' className="blue_button" />
             </Form>

--- a/src/pages/login/SignUpUser.tsx
+++ b/src/pages/login/SignUpUser.tsx
@@ -8,17 +8,18 @@ import { setSignUpProfile } from '../../utils/api/auth';
 
 const SignUpUser = () => {
 
-    // useForm 세팅
-    const { register, handleSubmit, formState: { errors } } = useForm<LoginSpace.SignUpProps>();
-    const onSubmit = handleSubmit(data => {
-        addProfile(data);
-    });
-
     // recoil 페이지 세팅
     const setPage = useSetRecoilState<LoginSpace.SignUpPageProps>(pageState);
 
     // 유저 이메일은 고정
-    const userEmail: string = JSON.parse(sessionStorage?.getItem('userProfile') || "")?.name;
+    const userEmail: string = JSON.parse(sessionStorage?.getItem('userProfile') || "")?.email;
+
+    // useForm 세팅
+    const { register, handleSubmit, formState: { errors } } = useForm<LoginSpace.SignUpProps>();
+    const onSubmit = handleSubmit(data => {
+        console.log('data', { ...data, email: userEmail });
+        addProfile({ ...data, email: userEmail });
+    });
 
     // 유저 추가 정보 업데이트하는 API
     async function addProfile(data: LoginSpace.SignUpProps) {
@@ -30,7 +31,6 @@ const SignUpUser = () => {
         }
         catch (error) { console.log('유저 추가 정보 업데이트 에러', error); };
     };
-
 
     // 더미 데이터
     const jobOptions = [

--- a/src/utils/api/auth.tsx
+++ b/src/utils/api/auth.tsx
@@ -73,44 +73,42 @@ export async function userLogin(
     url: "google" | "naver" | "github",
     props: RequestTokenSpace.GoogleToken | RequestTokenSpace.NaverToken | RequestTokenSpace.GithubToken,
 ) {
-    try {
-        const response = await axiosGetTokenConfig({
-            url: `${process.env.REACT_APP_SERVER_ADDRESS}/user/register/`, // 추후에 파라미터로 url 추가 예정
-            data: props,
-        })
 
-        const userProfile: LoginSpace.LoginUserProps = {
-            index: response.data.user_idx,
-            email: response.data.email,
-            name: response.data.name,
-        };
+    const response = await axiosGetTokenConfig({
+        url: `${process.env.REACT_APP_SERVER_ADDRESS}/user/register/`, // 추후에 파라미터로 url 추가 예정
+        data: props,
+    })
 
-        sessionStorage.setItem("userProfile", JSON.stringify(userProfile));
-        cookies.set('accessToken', response.data.tokens.access, {
-            path: '/',
-            expires: new Date(response.data.tokens.expired * 1000), // 테스트 기준 5분 (초 단위로 응답)
-            secure: true,
-            // httpOnly: true, // 배포하면 주석 제거 필수 (보안용)
-        });
-        cookies.set('refreshToken', response.data.tokens.refresh, {
-            path: '/',
-            expires: new Date(Date.now() + (60 * 60 * 24 * 1000)), // 테스트 기준 1일
-            secure: true,
-            // httpOnly: true, // 배포하면 주석 제거 필수 (보안용)
-        });
-
-        // 가입되지 않은 유저라면
-        if (response.data.register_check === "False") {
-            window.open('/signup', "_self");
-        }
-        // 가입된 유저라면
-        else {
-            window.open('/', "_self");
-        }
-    }
-    catch (error) {
-        console.log('로그인 에러', error)
+    const userProfile: LoginSpace.LoginUserProps = {
+        index: response.data.user_idx,
+        email: response.data.email,
+        name: response.data.name,
     };
+
+    sessionStorage.setItem("userProfile", JSON.stringify(userProfile));
+    cookies.set('accessToken', response.data.tokens.access, {
+        path: '/',
+        expires: new Date(response.data.tokens.expired * 1000), // 테스트 기준 5분 (초 단위로 응답)
+        secure: true,
+        // httpOnly: true, // 배포하면 주석 제거 필수 (보안용)
+    });
+    cookies.set('refreshToken', response.data.tokens.refresh, {
+        path: '/',
+        expires: new Date(Date.now() + (60 * 60 * 24 * 1000)), // 테스트 기준 1일
+        secure: true,
+        // httpOnly: true, // 배포하면 주석 제거 필수 (보안용)
+    });
+
+    return response.data.register_check;
+
+    // // 가입되지 않은 유저라면
+    // if (response.data.register_check === "False") {
+    //     window.open('/signup', "_self");
+    // }
+    // // 가입된 유저라면
+    // else {
+    //     window.open('/', "_self");
+    // }
 };
 
 // 회원가입 (추가 정보)

--- a/src/utils/api/auth.tsx
+++ b/src/utils/api/auth.tsx
@@ -115,7 +115,7 @@ export async function userLogin(
 export async function setSignUpProfile(data: LoginSpace.SignUpProps) {
     const response = await axiosGetUserConfig({
         method: 'patch',
-        url: '/user/profile',
+        url: '/user/profile/',
         data: data
     });
 

--- a/src/utils/api/auth.tsx
+++ b/src/utils/api/auth.tsx
@@ -88,8 +88,8 @@ export async function userLogin(
 
         const userProfile: LoginSpace.LoginUserProps = {
             index: response.data.user_idx,
-            userEmail: response.data.email,
-            userName: response.data.name,
+            email: response.data.email,
+            name: response.data.name,
         };
 
         sessionStorage.setItem("userProfile", JSON.stringify(userProfile));
@@ -97,13 +97,13 @@ export async function userLogin(
             path: '/',
             expires: new Date(response.data.tokens.expired * 1000), // 테스트 기준 5분 (초 단위로 응답)
             secure: true,
-            // httpOnly: true,
+            // httpOnly: true, // 배포하면 주석 제거 필수 (보안용)
         });
         cookies.set('refreshToken', response.data.tokens.refresh, {
             path: '/',
             expires: new Date(Date.now() + (60 * 60 * 24 * 1000)), // 테스트 기준 1일
             secure: true,
-            // httpOnly: true,
+            // httpOnly: true, // 배포하면 주석 제거 필수 (보안용)
         });
 
         // 가입되지 않은 유저라면
@@ -123,12 +123,12 @@ export async function userLogin(
 // 회원가입 (추가 정보)
 export async function setSignUpProfile(data: LoginSpace.SignUpProps) {
     const response = await axios({
-        method: 'put',
+        method: 'patch',
         url: '/user/profile',
         data: data
     });
 
-    return response.data;
+    return response;
 };
 
 // 직군 가져오기

--- a/src/utils/api/auth.tsx
+++ b/src/utils/api/auth.tsx
@@ -6,16 +6,6 @@ import MockAdapter from 'axios-mock-adapter';
 // request 테스트를 위한 코드
 // const mock = new MockAdapter(axios); // 가짜 response 객체 생성
 
-// mock.onPost('/user/register/google').reply(200, {
-//     user_idx: "1",
-//     email: "example@gmail.com",
-//     name: "김메롱",
-//     access_token: "sdhuweifh21uk378248efhfsjdf",
-//     refresh_token: "adlkasmcm91923uhgjd9si8ufh9d2",
-//     expires_in: Math.floor(new Date().getTime() + (60 * 5 * 1000)),
-//     register_check: true,
-// });
-
 // mock.onPut('/user/profile').reply(200, {
 //     result: true,
 // });
@@ -32,14 +22,22 @@ import MockAdapter from 'axios-mock-adapter';
 // 쿠키 객체 생성
 const cookies: Cookies = new Cookies();
 
-// axios 전역 설정 (서버에서 유저 정보 가져올 때)
-export const axiosGetUserConfig: AxiosInstance = axios.create({
-    baseURL: `${process.env.REACT_APP_SERVER_ADDRESS}`, // 기본 서버 주소 입력 => 아직 미정
+// axios 전역 설정 (토큰 가져올 때)
+const axiosGetTokenConfig: AxiosInstance = axios.create({
     method: 'post',
     headers: {
         'Content-Type': "application/json",
         'Accept': "application/json",
-        // 'Authorization': `Bearer ${cookies.get('accessToken')}`, // 로컬에 access_token이 존재할 경우 헤더에 넣어준다. => 자동으로 들어가는지 확인 필요
+    },
+});
+
+// axios 전역 설정 (서버에서 유저 정보 가져올 때)
+const axiosGetUserConfig: AxiosInstance = axios.create({
+    baseURL: `${process.env.REACT_APP_SERVER_ADDRESS}`, // 기본 서버 주소 입력 => 아직 미정
+    headers: {
+        'Content-Type': "application/json",
+        'Accept': "application/json",
+        'Authorization': `Bearer ${cookies?.get('accessToken')}`, // 로컬에 access_token이 존재할 경우 헤더에 넣어준다. => 자동으로 들어가는지 확인 필요
     }
 })
 
@@ -51,8 +49,7 @@ export async function getSnsLoginToken(
     clientSecretKey: string,
 ) {
     try {
-        const response = await axios({
-            method: 'post',
+        const response = await axiosGetTokenConfig({
             url: tokenResponseUri,
             params: {
                 client_id: clientId,
@@ -61,13 +58,9 @@ export async function getSnsLoginToken(
                 grant_type: 'authorization_code',
                 state: 'test',
             },
-            headers: {
-                'Content-Type': "application/json",
-                'Accept': "application/json",
-            }
         })
 
-        return response.data;
+        return response;
     }
     catch (error) {
         console.log('Authorization Token 에러');
@@ -81,8 +74,8 @@ export async function userLogin(
     props: RequestTokenSpace.GoogleToken | RequestTokenSpace.NaverToken | RequestTokenSpace.GithubToken,
 ) {
     try {
-        const response = await axiosGetUserConfig({
-            url: `/user/register/`, // 추후에 파라미터로 url 추가 예정
+        const response = await axiosGetTokenConfig({
+            url: `${process.env.REACT_APP_SERVER_ADDRESS}/user/register/`, // 추후에 파라미터로 url 추가 예정
             data: props,
         })
 
@@ -122,7 +115,7 @@ export async function userLogin(
 
 // 회원가입 (추가 정보)
 export async function setSignUpProfile(data: LoginSpace.SignUpProps) {
-    const response = await axios({
+    const response = await axiosGetUserConfig({
         method: 'patch',
         url: '/user/profile',
         data: data

--- a/src/utils/types/types.d.ts
+++ b/src/utils/types/types.d.ts
@@ -50,12 +50,12 @@ declare module 'LoginModule' {
 
         interface LoginUserProps {
             index: string;
-            userEmail: string;
-            userName: string;
+            email: string;
+            name: string;
         };
 
         interface SignUpProps extends LoginUserProps {
-            userJob: string;
+            job: string;
         };
 
         type SignUpPageProps = 0 | 1;

--- a/src/utils/types/types.d.ts
+++ b/src/utils/types/types.d.ts
@@ -59,7 +59,7 @@ declare module 'LoginModule' {
         };
 
         type SignUpPageProps = 0 | 1;
-    }
+    };
 
     export namespace RequestTokenSpace {
         interface GithubToken {


### PR DESCRIPTION
상황 1. 이미 로그인한 사람이 /login 또는 /signup 으로 진입할 때 (완료)
- session storage에 정보가 있을 때(= 로그인 중일 때) 접근하면 홈으로 강제 이동

상황 2. 아이디가 있는 사람이 회원가입 버튼을 눌렀을 때 (완료)
- 자동 로그인

상황 3. 아이디가 없는 사람이 로그인 버튼을 눌렀을 때 (완료)
- 회원가입 페이지로 이동

상황 4. 회원가입 중 페이지를 꺼버렸을 때 (예정)
- 플래그(true/false)를 두고 회원가입을 정상적으로 완료했을 때 true로 변경
- false 일 때 페이지를 끄면 회원탈퇴 API 사용